### PR TITLE
fix: fix clean-up order

### DIFF
--- a/src/restore/index.ts
+++ b/src/restore/index.ts
@@ -10,6 +10,23 @@ import {
 
 async function run(): Promise<void> {
   try {
+    /* 
+      clean up caches
+    */
+      const cacheBase = core.getState('cache-base')
+      const cleanKey = core.getInput('clean-key')
+      const CLEAN_TIME = 7
+  
+      if (cleanKey) {
+        await exec(
+          `/bin/bash -c "find ${cacheBase} -maxdepth 1 -name '${cleanKey}*' -type d -atime +${CLEAN_TIME} -exec rm -rf {} +"`
+        )
+      }
+    } catch (error) {
+      if (error instanceof Error) core.setFailed(error.message)
+    }
+
+  try {
     const key = core.getInput('key')
     const base = core.getInput('base')
     const path = core.getInput('path')

--- a/src/restore/index.ts
+++ b/src/restore/index.ts
@@ -23,7 +23,7 @@ async function run(): Promise<void> {
         )
       }
     } catch (error) {
-      if (error instanceof Error) core.setFailed(error.message)
+      if (error instanceof Error) core.warning(error.message)
     }
 
   try {

--- a/src/save/index.ts
+++ b/src/save/index.ts
@@ -21,18 +21,6 @@ async function run(): Promise<void> {
       core.info(`,not saving cache`)
     }
 
-    /* 
-      clean up caches
-    */
-    const cacheBase = core.getState('cache-base')
-    const cleanKey = core.getInput('clean-key')
-    const CLEAN_TIME = 7
-
-    if (cleanKey) {
-      await exec(
-        `/bin/bash -c "find ${cacheBase} -maxdepth 1 -name '${cleanKey}*' -type d -atime +${CLEAN_TIME} -exec rm -rf {} +"`
-      )
-    }
   } catch (error) {
     if (error instanceof Error) core.setFailed(error.message)
   }


### PR DESCRIPTION
## :pushpin: Type of PR
local cache의 purge 순서를 바꾸었습니다.

## :recycle: Current situation
- cache purge를 cache save 이후 action의 마지막 부분에서 합니다.
- cache restore이 먼저 이루어지고 purge가 되기 때문에 아래 문제가 발생합니다.
    - 일주일(expiration)이 지난 캐시의 경우도 restore이 먼저됩니다.
    - 액션이 끝나고 post 액션에서 cache save가 되고, 이후 바로 purge 됩니다.
    - 이후 다른 job에서 해당 캐시를 사용하려할 때 캐시가 삭제되어서 이미 있는 줄 알고 쓰려다 실패합니다.
 
## :bulb: Proposed solution
- purge를 restore 보다 먼저하는 것으로 변경하였습니다.
- purge 도중 익셉션 발생할 경우 액션이 멈출 수 있으니, try-catch 분리해서 따로 처리하였습니다.

## :gear: Release Notes
### :test_tube: Testing
* BEAT repo에서 테스팅 완료했습니다!
