### PR TITLE
Update symlink atime when restoring cache

### DIFF
--- a/src/restore/index.ts
+++ b/src/restore/index.ts
@@ -52,17 +52,18 @@ async function run(): Promise<void> {
     if (cacheHit === true) {
       const targetName = path.split('/').slice(-1)[0]
       const symlinkPath = `./${path}`
-      const ln = await exec(
-        `ln -s ${p.join(cachePath, targetName)} ${symlinkPath}`
-      )
+      const targetPath = p.join(cachePath, targetName)
     
+      // Create symlink
+      const ln = await exec(`ln -s ${targetPath} ${symlinkPath}`)
       core.debug(ln.stdout)
+    
       if (ln.stderr) {
         core.error(ln.stderr)
       } else {
-        // Touch symlink to update atime
-        await exec(`touch -a ${symlinkPath}`)
-        core.info(`Cache restored with key ${key} (atime updated)`)
+        // Touch the actual target file to update its atime
+        const touchResult = await exec(`touch -a ${targetPath}`)    
+        core.info(`Cache restored with key ${key}`)
       }
     } else {
       core.info(`Cache not found for ${key}`)

--- a/src/restore/index.ts
+++ b/src/restore/index.ts
@@ -50,13 +50,20 @@ async function run(): Promise<void> {
     core.setOutput('cache-hit', String(cacheHit))
 
     if (cacheHit === true) {
+      const targetName = path.split('/').slice(-1)[0]
+      const symlinkPath = `./${path}`
       const ln = await exec(
-        `ln -s ${p.join(cachePath, path.split('/').slice(-1)[0])} ./${path}`
+        `ln -s ${p.join(cachePath, targetName)} ${symlinkPath}`
       )
-
+    
       core.debug(ln.stdout)
-      if (ln.stderr) core.error(ln.stderr)
-      if (!ln.stderr) core.info(`Cache restored with key ${key}`)
+      if (ln.stderr) {
+        core.error(ln.stderr)
+      } else {
+        // Touch symlink to update atime
+        await exec(`touch -a ${symlinkPath}`)
+        core.info(`Cache restored with key ${key} (atime updated)`)
+      }
     } else {
       core.info(`Cache not found for ${key}`)
     }


### PR DESCRIPTION
Description:
When restoring cache, the target file’s access time (atime) was not being updated in some cases.
This could cause certain cleanup or cache retention strategies that rely on atime to behave incorrectly.

Change details:
	•	After creating the symlink during cache restore, added a touch -a command on the symlink target file 

Why this matters:
By updating the target file’s atime on restore, we ensure that cache retention policies relying on file access time work as expected and avoid unintentional cache purging.


How I test the touch works:
https://github.com/corca-ai/local-cache/issues/33
