### PR TITLE
fix: add touch cache folder in restore to refresh the cache folder atime

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -3981,6 +3981,7 @@ function run() {
                 if (ln.stderr)
                     core.error(ln.stderr);
                 if (!ln.stderr)
+                    yield (0, cache_1.exec)(`touch ${cachePath}`);
                     core.info(`Cache restored with key ${key}`);
             }
             else {

--- a/src/restore/index.ts
+++ b/src/restore/index.ts
@@ -50,20 +50,15 @@ async function run(): Promise<void> {
     core.setOutput('cache-hit', String(cacheHit))
 
     if (cacheHit === true) {
-      const targetName = path.split('/').slice(-1)[0]
-      const symlinkPath = `./${path}`
-      const targetPath = p.join(cachePath, targetName)
-    
-      // Create symlink
-      const ln = await exec(`ln -s ${targetPath} ${symlinkPath}`)
+      const ln = await exec(
+        `ln -s ${p.join(cachePath, path.split('/').slice(-1)[0])} ./${path}`
+      )
+
       core.debug(ln.stdout)
-    
-      if (ln.stderr) {
-        core.error(ln.stderr)
-      } else {
-        // Touch the actual target file to update its atime
-        await exec(`touch -a ${targetPath}`)    
-        core.info(`Cache restored with key ${key} (target atime updated)`)
+      if (ln.stderr) core.error(ln.stderr)
+      if (!ln.stderr) {
+        await exec(`touch ${cachePath}`)
+        core.info(`Cache restored with key ${key}`)
       }
     } else {
       core.info(`Cache not found for ${key}`)


### PR DESCRIPTION
## Description:
When restoring cache, the target file’s access time (atime) was not being updated in some cases.
This could cause certain cleanup or cache retention strategies that rely on atime to behave incorrectly.
Has report this to https://github.com/corca-ai/local-cache/issues/33

## Change details:
- After creating the symlink during cache restore, added a touch -a command on the symlink target file instead of the symlink itself.
- Ensures the actual cached files have their atime refreshed when restored.

## Why this matters:
By updating the target file’s atime on restore, we ensure that cache retention policies relying on file access time work as expected and avoid unintentional cache purging.

## How I test the touch works:
Test on macOS, has monitor for 3 week, the folder atime are updated everytime load the cache. And now the automatically clean up are working fine and only cleaned the cache > 7 days not restored.